### PR TITLE
Add response header check

### DIFF
--- a/lib/gateway.js
+++ b/lib/gateway.js
@@ -724,12 +724,12 @@ class Gateway extends EventEmitter {
     let validatedHeaders = Object.keys(responseHeaders).reduce((validatedHeaders, headerName) => {
       if (typeof headerName !== 'string') {
         errors[headerName] = {
-          message: `Header "${headerName}" must be a string`,
+          message: `Invalid response header name "${headerName}"`,
           invalid: true
         }
       } else if (headerName.match(/\s/)) {
         errors[headerName] = {
-          message: `"${headerName}" may not contain space characters`,
+          message: `Response header name "${headerName}" may not contain space characters`,
           invalid: true
         };
       } else if (
@@ -738,7 +738,7 @@ class Gateway extends EventEmitter {
         typeof responseHeaders[headerName] !== 'number'
       ) {
         errors[headerName] = {
-          message: `The value of "${headerName}" cannot be undefined or null`,
+          message: `The value of your "${headerName}" response header is missing or invalid`,
           invalid: true
         };
       } else {

--- a/lib/gateway.js
+++ b/lib/gateway.js
@@ -732,7 +732,11 @@ class Gateway extends EventEmitter {
           message: `"${headerName}" may not contain space characters`,
           invalid: true
         };
-      } else if (responseHeaders[headerName] === undefined || responseHeaders[headerName] === null) {
+      } else if (
+        typeof responseHeaders[headerName] !== 'string' &&
+        typeof responseHeaders[headerName] !== 'boolean' &&
+        typeof responseHeaders[headerName] !== 'number'
+      ) {
         errors[headerName] = {
           message: `The value of "${headerName}" cannot be undefined or null`,
           invalid: true

--- a/lib/gateway.js
+++ b/lib/gateway.js
@@ -415,6 +415,27 @@ class Gateway extends EventEmitter {
     );
   }
 
+  __invalidResponseHeaderError__ (req, res, details, executionUuid) {
+    let initialHeaders = {'content-type': 'application/json'};
+    if (executionUuid) {
+      initialHeaders['x-execution-uuid'] = executionUuid;
+    }
+    let headers = this.__createHeaders__(req, initialHeaders);
+    return this.__endRequest__(
+      502,
+      this.__formatHeaders__(headers),
+      req,
+      res,
+      JSON.stringify({
+        error: {
+          type: 'InvalidResponseHeaderError',
+          message: 'Your service returned invalid response headers',
+          details: details
+        }
+      })
+    );
+  }
+
   __valueError__ (req, res, details, executionUuid) {
     let initialHeaders = {'content-type': 'application/json'};
     if (executionUuid) {
@@ -696,6 +717,35 @@ class Gateway extends EventEmitter {
       errors: Object.keys(errors).length ? errors: null
     };
 
+  }
+
+  __validateResponseHeaders__ (responseHeaders) {
+    let errors = {};
+    let validatedHeaders = Object.keys(responseHeaders).reduce((validatedHeaders, headerName) => {
+      if (typeof headerName !== 'string') {
+        errors[headerName] = {
+          message: `Header "${headerName}" must be a string`,
+          invalid: true
+        }
+      } else if (headerName.match(/\s/)) {
+        errors[headerName] = {
+          message: `"${headerName}" may not contain space characters`,
+          invalid: true
+        };
+      } else if (responseHeaders[headerName] === undefined || responseHeaders[headerName] === null) {
+        errors[headerName] = {
+          message: `The value of "${headerName}" cannot be undefined or null`,
+          invalid: true
+        };
+      } else {
+        validatedHeaders[headerName] = responseHeaders[headerName];
+      }
+      return validatedHeaders;
+    }, {});
+    return {
+      headers: validatedHeaders,
+      errors: Object.keys(errors).length ? errors: null
+    };
   }
 
   __httpHandler__ (req, res) {
@@ -994,6 +1044,11 @@ class Gateway extends EventEmitter {
             this.log(req, `Autoformat Error (${dt}ms): ${err.message}`, 'error');
             return this.__autoformatError__(req, res, err.message, err.details, err.stack, executionUuid);
           }
+        }
+        let validated = this.__validateResponseHeaders__(httpResponse.headers);
+        if (validated.errors) {
+          this.log(req, `Invalid Response Header Error (${dt}ms)`, 'error');
+          return this.__invalidResponseHeaderError__(req, res, validated.errors, executionUuid);
         }
         this.log(req, `Execution Complete (${dt}ms)`);
         return this.__complete__(req, res, httpResponse.body, httpResponse.headers, httpResponse.statusCode, executionUuid);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "functionscript",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "An API gateway and framework for turning functions into web services",
   "author": "Keith Horwood <keithwhor@gmail.com>",
   "main": "index.js",

--- a/tests/gateway/functions/sanitize/http_object_invalid_header_names.js
+++ b/tests/gateway/functions/sanitize/http_object_invalid_header_names.js
@@ -1,0 +1,20 @@
+/**
+* Test rejection of invalid header names
+* @param {string} contentType A content type
+* @returns {object.http}
+*/
+module.exports = (contentType = 'text/html', callback) => {
+
+  return callback(null, {
+    body: 'hello',
+    headers: {
+      'Content-Type ': contentType,
+      'X Authorization Key': 'somevalue',
+      ' AnotherHeader': 'somevalue',
+      'WeirdName!@#$%^&*()œ∑´®†¥¨ˆøπåß∂ƒ©˙∆˚¬≈ç√∫˜µ≤:|\{}🔥🔥🔥': 'test',
+      'MultilineName\n': 'test',
+      'Good-Header-Name': 'good value'
+    }
+  });
+
+};

--- a/tests/gateway/functions/sanitize/http_object_invalid_header_values.js
+++ b/tests/gateway/functions/sanitize/http_object_invalid_header_values.js
@@ -13,6 +13,7 @@ module.exports = (contentType = 'text/html', callback) => {
       'Object-Value': {
         'a': 'b'
       },
+      'Number-Value': 0xdeadbeef,
       'Boolean-Value': false,
       'Empty-String-Value': ''
     }

--- a/tests/gateway/functions/sanitize/http_object_invalid_header_values.js
+++ b/tests/gateway/functions/sanitize/http_object_invalid_header_values.js
@@ -1,0 +1,21 @@
+/**
+* Test rejection of invalid header values
+* @param {string} contentType A content type
+* @returns {object.http}
+*/
+module.exports = (contentType = 'text/html', callback) => {
+
+  return callback(null, {
+    body: 'hello',
+    headers: {
+      'Null-Value': null,
+      'Undefined-Value': undefined,
+      'Object-Value': {
+        'a': 'b'
+      },
+      'Boolean-Value': false,
+      'Empty-String-Value': ''
+    }
+  });
+
+};

--- a/tests/gateway/tests.js
+++ b/tests/gateway/tests.js
@@ -601,6 +601,38 @@ module.exports = (expect) => {
     });
   });
 
+  it('Should return a proper error for invalid header names', done => {
+    request('GET', {}, '/sanitize/http_object_invalid_header_names/', '', (err, res, result) => {
+
+      expect(err).to.not.exist;
+      expect(res.statusCode).to.equal(502);
+      expect(result.error).to.exist;
+      expect(result.error.details).to.exist;
+      expect(Object.keys(result.error.details).length).to.equal(4);
+      expect(result.error.details['content-type ']).to.exist;
+      expect(result.error.details['x authorization key']).to.exist;
+      expect(result.error.details[' anotherheader']).to.exist;
+      expect(result.error.details['multilinename\n']).to.exist;
+      done();
+
+    });
+  });
+
+  it('Should return a proper error for invalid header values', done => {
+    request('GET', {}, '/sanitize/http_object_invalid_header_values/', '', (err, res, result) => {
+
+      expect(err).to.not.exist;
+      expect(res.statusCode).to.equal(502);
+      expect(result.error).to.exist;
+      expect(result.error.details).to.exist;
+      expect(Object.keys(result.error.details).length).to.equal(2);
+      expect(result.error.details['undefined-value']).to.exist;
+      expect(result.error.details['null-value']).to.exist;
+      done();
+
+    });
+  });
+
   it('Should not accept object.http with null body', done => {
     request('GET', {}, '/sanitize/http_object/', '', (err, res, result) => {
 

--- a/tests/gateway/tests.js
+++ b/tests/gateway/tests.js
@@ -625,7 +625,8 @@ module.exports = (expect) => {
       expect(res.statusCode).to.equal(502);
       expect(result.error).to.exist;
       expect(result.error.details).to.exist;
-      expect(Object.keys(result.error.details).length).to.equal(2);
+      expect(Object.keys(result.error.details).length).to.equal(3);
+      expect(result.error.details['object-value']).to.exist;
       expect(result.error.details['undefined-value']).to.exist;
       expect(result.error.details['null-value']).to.exist;
       done();


### PR DESCRIPTION
Currently, non-string header values other than undefined all seem to work. I disallowed `null` as well because it was confusing, but do we want to disallow anything that's not a string?